### PR TITLE
Fix bug in score updates

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -1264,8 +1264,8 @@ impl GameState {
 
         // Winner collects all riichi and honba sticks that were on the table.
         // This is added ON TOP of the hand payments.
-        self.player_scores[winning_player_seat] += (self.riichi_sticks as i32 * 1000);
-        self.player_scores[winning_player_seat] += (self.honba_sticks as i32 * 300);
+        self.player_scores[winning_player_seat] += self.riichi_sticks as i32 * 1000;
+        self.player_scores[winning_player_seat] += self.honba_sticks as i32 * 300;
 
         self.riichi_sticks = 0; // Reset riichi sticks from table
         // Honba sticks for the *next* round are determined by Env based on game outcome,


### PR DESCRIPTION
## Summary
- fix parentheses when adding riichi/honba sticks to winner's score

## Testing
- `cargo test` *(fails: could not compile `sanma_engine`)*

------
https://chatgpt.com/codex/tasks/task_e_684367e8a790832f8388a0cee772e463