### PR TITLE
Fix PyDict initialization in Env::step

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl Env {
 
         let mut reward = 0.0;
         let mut done = false;
-        let info = PyDict::new(py)?;
+        let info = PyDict::new(py);
 
         if self.current_phase == GamePhase::RoundOver {
             info.set_item("status", "RoundOver, please reset")?;


### PR DESCRIPTION
## Summary
- fix info dict creation in `Env::step`

## Testing
- `cargo test` *(fails: could not compile `sanma_engine`)*

------
https://chatgpt.com/codex/tasks/task_e_684367dc48a4832f94a3211dbb8eb62e