### PR TITLE
refactor fu calc types and remove unused vars

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -1183,7 +1183,7 @@ impl GameState {
                     is_menzen_win: menzen,
                     seat_wind: self.seat_winds[winning_player_seat],
                     round_wind: self.round_wind,
-                    hand_before_win_completion: None, // TODO: Consider providing for more accurate wait Fu
+                    _hand_before_win_completion: None, // TODO: Consider providing for more accurate wait Fu
                 };
                 fu_calculation::calculate_fu(&fu_input)
             }
@@ -2186,6 +2186,7 @@ mod tests {
     use crate::hand::Hand;
     use crate::hand_parser;
     use crate::game_state::{WinType, DeclaredMeldType, Score, DeclaredMeld}; // Explicitly import
+    use crate::wall::DEAD_WALL_SIZE;
 
     // --- Helper Functions ---
 


### PR DESCRIPTION
## Summary
- clean up unused meld info tracking
- prefix unused struct fields with `_`
- restructure wait fu logic
- update tests and constants usage

## Testing
- `cargo test` *(fails: could not compile `sanma_engine` due to errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843705cfa40832f9dc49d98eef94604