### PR TITLE
Update pymodule signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // src/lib.rs
 use pyo3::prelude::*;
+use pyo3::Bound;
 use numpy::{PyArray, PyArray1, Ix3};
 use pyo3::types::PyDict;
 use pyo3::exceptions::{PyValueError, PyIndexError};
@@ -745,7 +746,7 @@ impl Env {
 }
 
 #[pymodule]
-fn sanma_engine(_py: Python, m: &PyModule) -> PyResult<()> {
+fn sanma_engine(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Env>()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- import `pyo3::Bound`
- use `Bound<'_, PyModule>` for the `sanma_engine` module initializer

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684370646834832fa1b2c8522ace3598