### PR TITLE
Improve dataset preparation

### DIFF
--- a/tests/test_process_round.py
+++ b/tests/test_process_round.py
@@ -13,4 +13,4 @@ def test_process_round_sample():
     round_data = data['log'][0]
     env = Env()
     pairs = process_round(round_data, env)
-    assert len(pairs) == 24
+    assert len(pairs) == 33


### PR DESCRIPTION
## Summary
- handle replacement draws after special actions
- fallback riichi actions to normal discard if illegal
- keep engine in sync by replacing illegal moves with PASS
- update test expectation

## Testing
- `pytest -q`
- `python prepare_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68481883cd54832fa43152f5f447bf8e