### PR TITLE
Improve round processing with logging and resilience

### DIFF
--- a/tests/test_process_round.py
+++ b/tests/test_process_round.py
@@ -14,3 +14,45 @@ def test_process_round_sample():
     env = Env()
     pairs = process_round(round_data, env)
     assert len(pairs) == 33
+
+
+def test_process_round_continues_on_error(monkeypatch):
+    with open('tests/data/sample_round.json', 'r') as f:
+        data = json.load(f)
+    round_data = data['log'][0]
+
+    baseline_env = Env()
+    baseline_pairs = process_round(round_data, baseline_env)
+
+    class WrapperEnv:
+        def __init__(self):
+            self.inner = Env()
+            self.count = 0
+
+        def reset(self, *a, **kw):
+            return self.inner.reset(*a, **kw)
+
+        def get_game_phase_pystr(self):
+            return self.inner.get_game_phase_pystr()
+
+        def current_player_idx_py(self):
+            return self.inner.current_player_idx_py()
+
+        def get_obs_and_legal_actions(self):
+            return self.inner.get_obs_and_legal_actions()
+
+        def step(self, action_id):
+            result = self.inner.step(action_id)
+            self.count += 1
+            if self.count == 5:
+                raise ValueError('boom')
+            return result
+
+        def get_last_drawn_tile_for_current_player_val(self):
+            return self.inner.get_last_drawn_tile_for_current_player_val()
+
+    env = WrapperEnv()
+
+    pairs = process_round(round_data, env)
+
+    assert len(pairs) == len(baseline_pairs)


### PR DESCRIPTION
## Summary
- add debug logs for early exits in `process_round`
- keep replaying actions when env.step fails
- warn if parsed actions don't match raw log counts
- verify that rounds continue after a step error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684873c675d0832f85a25f7589ff2821