### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,25 @@
 
 ## Setup
 
-Install Python dependencies and build the Rust extension:
+Follow these steps to build and verify the project:
 
-```bash
-pip install -r requirements.txt
-maturin develop --release
-```
+1. **Install dependencies and `maturin`:**
+   ```bash
+   pip install -r requirements.txt
+   pip install maturin
+   ```
 
-Run tests with:
+2. **Build and install the Rust extension:**
+   ```bash
+   maturin develop --release
+   ```
 
-```bash
-pytest -q
-```
+3. **Run the tests to verify the installation:**
+   ```bash
+   pytest -q
+   ```
 
-Prepare dataset files with:
+`prepare_dataset.py` also relies on the compiled extension, so make sure it is built before running:
 
 ```bash
 python prepare_dataset.py


### PR DESCRIPTION
## Summary
- expand the README setup section with a numbered guide
- mention that `prepare_dataset.py` needs the Rust extension

## Testing
- `pip install maturin -qq`
- `maturin develop --release` *(fails: rust compiler not installed)*
- `pytest -q` *(fails: cannot import `sanma_engine`)*

------
https://chatgpt.com/codex/tasks/task_e_684877111774832f8bfe148a6076839a